### PR TITLE
Fix some js include paths for successful npm build

### DIFF
--- a/src/app/Writers/ViewsWriter.php
+++ b/src/app/Writers/ViewsWriter.php
@@ -12,7 +12,6 @@ class ViewsWriter
 
     private $choices;
     private $path;
-    private $depth;
 
     public function __construct(Obj $choices)
     {
@@ -23,7 +22,6 @@ class ViewsWriter
         );
 
         $this->path = resource_path(self::PathPrefix.'/'.$segments->implode('/'));
-        $this->depth = $segments->count();
     }
 
     public function run()
@@ -34,7 +32,7 @@ class ViewsWriter
 
     private function createFolders()
     {
-        if (!\File::isDirectory($this->path)) {
+        if (! \File::isDirectory($this->path)) {
             \File::makeDirectory($this->path, 0755, true);
         }
 
@@ -68,7 +66,6 @@ class ViewsWriter
             '${models}' => Str::plural(Str::snake(
                 $this->choices->get('model')->get('name'))
             ),
-            '${depth}' => str_repeat('../', $this->depth),
         ];
 
         return [

--- a/src/app/Writers/stubs/pages/index.stub
+++ b/src/app/Writers/stubs/pages/index.stub
@@ -5,7 +5,7 @@
 
 <script>
 
-import VueTable from '${depth}../components/enso/vuedatatable/VueTable.vue';
+import VueTable from '@enso-ui/tables/bulma';
 
 export default {
     name: 'Index',

--- a/src/app/Writers/stubs/routes/parentSegment.stub
+++ b/src/app/Writers/stubs/routes/parentSegment.stub
@@ -1,7 +1,7 @@
 import routeImporter from '@core-modules/importers/routeImporter';
 
 const routes = routeImporter(require.context('./${segment}', false, /.*\.js$/));
-const RouterView = () => import('@core-pages/core/Router.vue');
+const RouterView = () => import('@core-pages/Router.vue');
 
 export default {
     path: '${relativePath}',


### PR DESCRIPTION
Hello. With today's default installation and after following instructions under https://docs.laravel-enso.com/packages/structure-manager.html#cli-details 
making "yarn dev" fails referring this paths:
 '../../../components/enso/vuedatatable/VueTable.vue'
 - (fixed to '@enso-ui/tables/bulma')
'@core-pages/core/Router.vue' 
 - (fixed to '@core-pages/Router.vue')

I can provide versions of other packages if you need some, composer.lock is kinda big and I do not know what actual version of my current packages you may need to test issue.
my current
 laravel-enso/core is 4.0.8
 laravel-enso/structuremanager is 3.0.2



